### PR TITLE
feat: 漫画列表页本地收藏自动选择默认收藏夹

### DIFF
--- a/lib/views/widgets/comic_tile.dart
+++ b/lib/views/widgets/comic_tile.dart
@@ -142,7 +142,7 @@ abstract class ComicTile extends StatelessWidget {
             outline: true,
             width: 156,
             values: LocalFavoritesManager().folderNames,
-            initialValue: null,
+            initialValue: LocalFavoritesManager().folderNames.indexOf(appdata.settings[51]),
             whenChange: (i) => folder = LocalFavoritesManager().folderNames[i],
           ),
         ),


### PR DESCRIPTION
漫画列表页长按漫画项后，本地收藏会自动选择设置里配置的默认收藏夹

![image](https://github.com/wgh136/PicaComic/assets/33375791/c453f46e-9e09-4af3-b36d-a53cdbc4b7f1)
![image](https://github.com/wgh136/PicaComic/assets/33375791/a8341d4d-4acd-4968-8bdf-dfdb885a0eeb)
