### PR TITLE
通过 ehview 复制来的 cookie 实现自动填充

### DIFF
--- a/assets/translation.json
+++ b/assets/translation.json
@@ -530,7 +530,11 @@
     "是否退出程序？" : "是否退出程序？",
     "不再提示": "不再提示",
     "删除下载": "刪除下載",
-    "复制路径": "複製路徑"
+    "复制路径": "複製路徑",
+    "通过 cookie 身份信息快速填写": "通過 cookie 身份信息快速填寫",
+    "解析": "解析",
+    "空的内容不能解析哦": "空的內容不能解析哦",
+    "cookie 信息格式可能有误": "cookie 格式可能有誤"
   },
   "en_US": {
     "有可用更新": "Updates available",
@@ -1060,6 +1064,10 @@
     "是否退出程序？" : "Exit the program?",
     "不再提示": "Do not show again",
     "删除下载": "Delete download",
-    "复制路径": "Copy path"
+    "复制路径": "Copy path",
+    "通过 cookie 身份信息快速填写": "Quickly fill in identity information through cookies",
+    "解析": "Parse",
+    "空的内容不能解析哦": "Empty content cannot be parsed",
+    "cookie 信息格式可能有误": "Cookie information format may be incorrect"
   }
 }

--- a/lib/base.dart
+++ b/lib/base.dart
@@ -135,8 +135,8 @@ class Appdata {
 
   void readImplicitData() async {
     var s = await SharedPreferences.getInstance();
-    var data = s.getStringList("implicitData");
-    for(int i = 0; i < data!.length && i < implicitData.length; i++) {
+    var data = s.getStringList("implicitData") ?? [];
+    for (int i = 0; i < data.length && i < implicitData.length; i++) {
       implicitData[i] = data[i];
     }
   }
@@ -235,9 +235,9 @@ class Appdata {
   Future<void> readSettings(SharedPreferences s) async {
     var settingsFile = File("${App.dataPath}/settings");
     List<String> st;
-    if(settingsFile.existsSync()) {
+    if (settingsFile.existsSync()) {
       var json = jsonDecode(await settingsFile.readAsString());
-      if(json is List){
+      if (json is List) {
         st = List.from(json);
       } else {
         st = [];
@@ -256,7 +256,7 @@ class Appdata {
   Future<void> updateSettings([bool syncData = true]) async {
     var settingsFile = File("${App.dataPath}/settings");
     await settingsFile.writeAsString(jsonEncode(settings));
-    if(syncData) {
+    if (syncData) {
       Webdav.uploadData();
     }
   }
@@ -273,7 +273,7 @@ class Appdata {
   }
 
   Future<void> writeData([bool sync = true]) async {
-    if(sync) {
+    if (sync) {
       Webdav.uploadData();
     }
     var s = await SharedPreferences.getInstance();
@@ -370,7 +370,7 @@ class Appdata {
       jmPwd = json["jmPwd"];
       htName = json["htName"];
       htPwd = json["htPwd"];
-      if(json["history"] != null) {
+      if (json["history"] != null) {
         history.readDataFromJson(json["history"]);
       }
       blockingKeyword = List.from(json["blockingKeywords"] ?? blockingKeyword);
@@ -392,7 +392,7 @@ Future<void> clearAppdata() async {
   var s = await SharedPreferences.getInstance();
   await s.clear();
   var settingsFile = File("${App.dataPath}/settings");
-  if(await settingsFile.exists()) {
+  if (await settingsFile.exists()) {
     await settingsFile.delete();
   }
   appdata.history.clearHistory();

--- a/lib/views/eh_views/eh_login_page.dart
+++ b/lib/views/eh_views/eh_login_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_windows_webview/flutter_windows_webview.dart';
 import 'package:pica_comic/views/app_views/webview.dart';
+import 'package:pica_comic/views/eh_views/eh_widgets/eh_user_cookie_parser.dart';
 import 'package:pica_comic/views/widgets/show_message.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:pica_comic/tools/translations.dart';
@@ -23,6 +24,23 @@ class _EhLoginPageState extends State<EhLoginPage> {
   final c3 = TextEditingController();
   final c4 = TextEditingController();
   bool logging = false;
+  late EhUserCookieParserController cookieParserController;
+
+  @override
+  void initState() {
+    super.initState();
+    cookieParserController = EhUserCookieParserController();
+  }
+
+  @override
+  void dispose() {
+    c1.dispose();
+    c2.dispose();
+    c3.dispose();
+    c4.dispose();
+
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -39,13 +57,14 @@ class _EhLoginPageState extends State<EhLoginPage> {
                 width: 400,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    Text(
-                      "  Cookies".tl,
-                      style: const TextStyle(fontSize: 18),
-                    ),
+                    _buildHeader(cookieParserController),
                     const SizedBox(
                       height: 3,
+                    ),
+                    EhUserCookieParser(
+                      controller: cookieParserController,
                     ),
                     Padding(
                       padding: const EdgeInsets.all(5),
@@ -151,6 +170,64 @@ class _EhLoginPageState extends State<EhLoginPage> {
           ],
         ),
       ),
+    );
+  }
+
+  Row _buildHeader(EhUserCookieParserController cookieParserController) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Text(
+            "  Cookies".tl,
+            style: const TextStyle(fontSize: 18),
+          ),
+        ),
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 500),
+          switchInCurve: Curves.easeInOut,
+          switchOutCurve: Curves.easeInOut,
+          child: cookieParserController.visible
+              ? _buildCookieParserButtonGroup(cookieParserController)
+              : TextButton(
+                  onPressed: () {
+                    if (cookieParserController.visible) return;
+                    cookieParserController.show();
+                    setState(() {});
+                  },
+                  child: Text('通过 cookie 身份信息快速填写'.tl),
+                ),
+        )
+      ],
+    );
+  }
+
+  Row _buildCookieParserButtonGroup(
+      EhUserCookieParserController cookieParserController) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextButton(
+          onPressed: () {
+            cookieParserController.hide();
+            setState(() {});
+          },
+          child: Text('隐藏'.tl),
+        ),
+        const SizedBox(width: 16),
+        FilledButton(
+          onPressed: () {
+            final cookieMap = cookieParserController.parse();
+            setState(() {
+              c1.text = cookieMap['ipb_member_id'] ?? '';
+              c2.text = cookieMap['ipb_pass_hash'] ?? '';
+              c3.text = cookieMap['igneous'] ?? '';
+              c4.text = cookieMap['star'] ?? '';
+            });
+          },
+          child: Text('解析'.tl),
+        ),
+      ],
     );
   }
 

--- a/lib/views/eh_views/eh_login_page.dart
+++ b/lib/views/eh_views/eh_login_page.dart
@@ -227,6 +227,7 @@ class _EhLoginPageState extends State<EhLoginPage> {
           },
           child: Text('解析'.tl),
         ),
+        const SizedBox(width: 4),
       ],
     );
   }

--- a/lib/views/eh_views/eh_widgets/eh_user_cookie_parser.dart
+++ b/lib/views/eh_views/eh_widgets/eh_user_cookie_parser.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:pica_comic/tools/translations.dart';
+import 'package:pica_comic/views/widgets/show_message.dart';
+
+const sample = '''ipb_member_id: ...
+ipb_pass_hash: ...
+igneous: ...
+star: ...''';
+
+class EhUserCookieParser extends StatefulWidget {
+  const EhUserCookieParser({super.key, required this.controller});
+
+  final EhUserCookieParserController controller;
+
+  @override
+  State<EhUserCookieParser> createState() => _EhUserCookieParserState();
+}
+
+class _EhUserCookieParserState extends State<EhUserCookieParser>
+    with SingleTickerProviderStateMixin {
+  late TextEditingController cookieDataController;
+  late Map<String, String> cookieMap;
+
+  late AnimationController scaleController;
+  late Animation<double> scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    cookieDataController = TextEditingController();
+
+    scaleController = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 500));
+    scaleAnimation = Tween(begin: 0.0, end: 1.0).animate(CurvedAnimation(
+      parent: scaleController,
+      curve: Curves.easeInOut,
+    ));
+
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      widget.controller.setFunctions(show, hide, parse);
+    });
+  }
+
+  @override
+  void dispose() {
+    cookieDataController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: scaleAnimation,
+      builder: (context, child) => Center(
+        child: SizedBox(
+          height: 150 * scaleAnimation.value,
+          child: Transform.scale(
+            scale: scaleAnimation.value,
+            child: Padding(
+              padding: const EdgeInsets.all(5),
+              child: TextField(
+                maxLines: null,
+                minLines: 5,
+                scrollPhysics: const AlwaysScrollableScrollPhysics(),
+                controller: cookieDataController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: sample.tl,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void show() {
+    scaleController.forward();
+  }
+
+  void hide() {
+    scaleController.reverse();
+  }
+
+  Map<String, String> parse() {
+    if (cookieDataController.text.isEmpty) {
+      showMessage(context, "空的内容不能解析哦".tl);
+      return {};
+    }
+    cookieMap = {};
+    final rawCookieData = cookieDataController.text;
+    final cookieDataPairs = rawCookieData.split('\n');
+    for (var pair in cookieDataPairs) {
+      final splitData = pair.split(':');
+      if (splitData.length != 2) {
+        showMessage(context, "cookie 信息格式可能有误".tl);
+        continue;
+      }
+      final key = splitData[0].trim();
+      final value = splitData[1].trim();
+      cookieMap[key] = value;
+    }
+    return cookieMap;
+  }
+}
+
+class EhUserCookieParserController {
+  EhUserCookieParserController();
+
+  void Function()? showFunction, hideFunction;
+  Map<String, String> Function()? parseFunction;
+
+  var visible = false;
+
+  void setFunctions(
+      Function() show, Function() hide, Map<String, String> Function() parse) {
+    showFunction = show;
+    hideFunction = hide;
+    parseFunction = parse;
+  }
+
+  void show() {
+    if (visible) return;
+    visible = true;
+    showFunction?.call();
+  }
+
+  void hide() {
+    if (!visible) return;
+    visible = false;
+    hideFunction?.call();
+  }
+
+  Map<String, String> parse() {
+    return parseFunction?.call() ?? {};
+  }
+}


### PR DESCRIPTION
**预览**

![image](https://github.com/user-attachments/assets/13696d6b-bf35-4f45-b818-391308be3b9d)

旨在给原 eh 用户提供一个更方便的 cookie 填写方法，一个一个复制太麻烦了！

![image](https://github.com/user-attachments/assets/31986c7c-fb34-45a3-911d-922ac40bdfab)


所以添加了一个能够直接解析 ehviewer 中复制过来的 cookie 来填充的方式
测试了 windows 和 android 手机，手头没有设备所以 iphone、ipad、平板都未经测试；i18n 完成

碎碎念：为什么不使用如 bloc、riverpod 这样的状态管理呢，感觉 setState 用起来并不是很方便🤔